### PR TITLE
strip debug info, shrink image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine AS builder
 RUN apk add --no-cache gcc libc-dev
 WORKDIR /nitro
 COPY . .
-RUN GOOS=linux go build -o nitro ./cmd/nitro
+RUN GOOS=linux go build -ldflags="-s -w" -o nitro ./cmd/nitro
 
 FROM google/shaka-packager AS packager
 RUN packager -version


### PR DESCRIPTION
Hi LuaxY:
we can use [`-s` and `-w` linker flags](https://golang.org/cmd/link/)  to strip the debugging info, we don't need these in our image, and  this can reduce image size.  to prove this, I do it on my laptop
1. without `-s` and  `-w` options in Dockerfile:
```sh
docker build -t luaxy/nitro:v0.1  . 

Sending build context to Docker daemon  22.81MB
Step 1/14 : FROM golang:alpine AS builder
 ---> 1de1afaeaa9a
Step 2/14 : RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories && go env -w  GOPROXY="https://goproxy.io,direct" && apk add --no-cache gcc libc-dev
 ---> Using cache
 ---> d56813dfb77b
Step 3/14 : WORKDIR /nitro
 ---> Using cache
 ---> 85714b144bdc
Step 4/14 : COPY . .
 ---> bb48b0333910
Step 5/14 : RUN GOOS=linux go build -o nitro ./cmd/nitro
..........
Step 14/14 : ENTRYPOINT [ "/nitro" ]
 ---> Running in ee116b1ae1c8
Removing intermediate container ee116b1ae1c8
 ---> c1058c065ddf
Successfully built c1058c065ddf
Successfully tagged luaxy/nitro:v0.1
-----------------------------------------------------
```
2. with `-s` and  `-w` options in Dockerfile:
```sh
docker build -t luaxy/nitro:v0.2  .                                                                                                                                                                

Sending build context to Docker daemon  22.81MB
Step 1/14 : FROM golang:alpine AS builder
 ---> 1de1afaeaa9a
Step 2/14 : RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories && go env -w  GOPROXY="https://goproxy.io,direct" && apk add --no-cache gcc libc-dev
 ---> Using cache
 ---> d56813dfb77b
Step 3/14 : WORKDIR /nitro
 ---> Using cache
 ---> 85714b144bdc
Step 4/14 : COPY . .
 ---> 6f0fb8f5fa23
Step 5/14 : RUN GOOS=linux go build -ldflags="-s -w" -o nitro ./cmd/nitro
...............
 ---> 1c09b8087940
Successfully built 1c09b8087940
Successfully tagged luaxy/nitro:v0.2
```
3. the different image size between v0.1 and v0.2:
```sh
docker images                                                                                                                                                                                       
REPOSITORY              TAG                 IMAGE ID       CREATED          SIZE
luaxy/nitro             v0.2                1c09b8087940   4 seconds ago    97.6MB
luaxy/nitro             v0.1                c1058c065ddf   3 minutes ago    107MB
```
we **save 9.4 MB** disk space,  if a guy want to pull this image, this will save his download time a little!

and if you just compile the binary with different strategry, the binary size if differnet:
```sh
go build  -o nitro ./cmd/nitro
ls -sialh  nitro 
6036522 34M -rwxr-xr-x 1 brown users 34M Dec 25 02:30 nitro

go build -ldflags="-s -w" -o nitro ./cmd/nitro
ls -sialh  nitro 
6036526 25M -rwxr-xr-x 1 brown users 25M Dec 25 02:29 nitro
```

















